### PR TITLE
Global GitHub PAT Management

### DIFF
--- a/docs/implementation-plan-docstrings.md
+++ b/docs/implementation-plan-docstrings.md
@@ -1,0 +1,153 @@
+# Implementation Plan: API Route Documentation with Docstrings
+
+## Overview
+This plan outlines adding comprehensive docstrings to all API routes in `/home/filipp/space-goose/k8s-manager/routes/project_routes.py` to improve code documentation and API understanding.
+
+## Current State Analysis
+- **File**: `/home/filipp/space-goose/k8s-manager/routes/project_routes.py`
+- **Current Routes**: 23 API endpoints
+- **Documentation Status**: Most routes lack proper docstrings
+- **Existing Docstrings**: Only 3 routes have docstrings currently
+
+## Task 1: Add Docstrings to All Routes
+
+### Routes Requiring Docstrings (20 routes):
+
+#### User Management Routes
+1. `GET /users` - `get_users()`
+2. `GET /users/{user_id}/projects` - `get_projects()`
+
+#### Project Management Routes  
+3. `POST /users/{user_id}/projects` - `create_project()`
+4. `PUT /users/{user_id}/projects/{project_id}` - `update_project()`
+5. `DELETE /users/{user_id}/projects/{project_id}` - `delete_project()`
+6. `POST /users/{user_id}/projects/{project_id}/activate` - `activate_project()`
+7. `POST /users/{user_id}/projects/{project_id}/deactivate` - `deactivate_project()`
+
+#### Session Management Routes
+8. `POST /users/{user_id}/projects/{project_id}/sessions` - `create_session()` ✅ (has docstring)
+9. `GET /users/{user_id}/projects/{project_id}/sessions` - `get_project_sessions()` ✅ (has docstring)
+10. `DELETE /users/{user_id}/projects/{project_id}/sessions/{session_id}` - `delete_session()` ✅ (has docstring)
+11. `GET /users/{user_id}/projects/{project_id}/sessions/{session_id}/messages` - `get_session_messages()` ✅ (has docstring)
+
+#### Extension Management Routes
+12. `GET /users/{user_id}/projects/{project_id}/extensions` - `get_project_extensions()`
+13. `POST /users/{user_id}/projects/{project_id}/extensions` - `create_project_extension()`
+14. `PUT /users/{user_id}/projects/{project_id}/extensions/{extension_name}/toggle` - `toggle_project_extension()`
+15. `DELETE /users/{user_id}/projects/{project_id}/extensions/{extension_name}` - `delete_project_extension()`
+
+#### Messaging Routes
+16. `POST /users/{user_id}/projects/{project_id}/messages` - `proxy_message()` ✅ (has docstring)
+17. `POST /users/{user_id}/projects/{project_id}/messages/send` - `send_message_sync()`
+
+#### Settings Management Routes
+18. `GET /users/{user_id}/projects/{project_id}/settings` - `get_project_settings()` ✅ (has docstring)
+19. `GET /users/{user_id}/projects/{project_id}/settings/{setting_key}` - `get_project_setting()` ✅ (has docstring)
+20. `PUT /users/{user_id}/projects/{project_id}/settings/{setting_key}` - `update_project_setting()` ✅ (has docstring)
+21. `DELETE /users/{user_id}/projects/{project_id}/settings/{setting_key}` - `reset_project_setting()` ✅ (has docstring)
+22. `PUT /users/{user_id}/projects/{project_id}/settings` - `update_project_settings_bulk()` ✅ (has docstring)
+
+#### GitHub Integration Routes
+23. `PUT /users/{user_id}/projects/{project_id}/github-key` - `update_project_github_key()` ✅ (has docstring)
+
+### Docstring Format Standard
+
+Each docstring should follow this format:
+```python
+"""
+Brief description of what the endpoint does.
+
+Args:
+    param1 (type): Description of parameter
+    param2 (type): Description of parameter
+    
+Returns:
+    dict: Description of return value structure
+    
+Raises:
+    HTTPException: When and why exceptions are raised
+    
+Example:
+    Brief usage example or important notes
+"""
+```
+
+## Implementation Steps
+
+### Step 1: User Management Routes
+- Add docstring to `get_users()` - Returns list of available users
+- Add docstring to `get_projects()` - Lists all projects for a specific user
+
+### Step 2: Project Management Routes  
+- Add docstring to `create_project()` - Creates new project with K8s resources
+- Add docstring to `update_project()` - Updates project name and metadata
+- Add docstring to `delete_project()` - Removes project and all K8s resources  
+- Add docstring to `activate_project()` - Scales up deployment and gets endpoint
+- Add docstring to `deactivate_project()` - Scales down deployment
+
+### Step 3: Extension Management Routes
+- Add docstring to `get_project_extensions()` - Lists all extensions for active project
+- Add docstring to `create_project_extension()` - Creates new extension (stdio/HTTP)
+- Add docstring to `toggle_project_extension()` - Enables/disables extension
+- Add docstring to `delete_project_extension()` - Removes extension from project
+
+### Step 4: Messaging Routes  
+- Add docstring to `send_message_sync()` - Fire-and-forget message sending
+
+### Step 5: Helper Functions
+- Add docstring to `update_project_env_vars()` - Updates K8s environment variables
+
+## Quality Standards
+
+### Content Requirements
+- **Purpose**: Clear, one-line summary of the endpoint's function
+- **Parameters**: Document all path, query, and body parameters with types
+- **Returns**: Describe the response structure and HTTP status codes
+- **Exceptions**: Document all possible HTTPException scenarios
+- **Context**: Include important behavioral notes (e.g., "Project must be active")
+
+### Examples of Good Docstrings
+```python
+"""
+Create a new project with Kubernetes resources.
+
+Creates a project with associated K8s deployment, service, and configmap.
+The project starts in 'inactive' status and must be activated separately.
+
+Args:
+    user_id (str): ID of the user creating the project
+    project (ProjectCreate): Project creation data including name and optional GitHub key
+    
+Returns:
+    dict: Success message and project_id
+    
+Raises:
+    HTTPException 500: If K8s resource creation fails
+    HTTPException 400: If project data is invalid
+    
+Note:
+    If GitHub key is provided, it's stored securely in K8s secrets.
+"""
+```
+
+## Deliverables
+
+1. **Updated project_routes.py** with comprehensive docstrings
+2. **Consistent documentation style** across all routes  
+3. **Clear API behavior documentation** for frontend integration
+4. **Better developer experience** for future maintenance
+
+## Success Criteria
+
+- ✅ All 20+ routes have comprehensive docstrings
+- ✅ Docstrings follow consistent format and style
+- ✅ All parameters, returns, and exceptions are documented
+- ✅ Code remains functionally unchanged
+- ✅ Documentation aids in API understanding and maintenance
+
+## Estimated Effort
+
+- **Time**: 2-3 hours
+- **Complexity**: Low (documentation only, no logic changes)
+- **Risk**: Very low (no functional changes)
+- **Dependencies**: None

--- a/docs/implementation-plan-global-github-pat.md
+++ b/docs/implementation-plan-global-github-pat.md
@@ -1,0 +1,396 @@
+# Implementation Plan: Global GitHub PAT Management
+
+## Overview
+This plan outlines implementing a global GitHub Personal Access Token (PAT) management system that allows users to set a default GitHub token at the user level, which is automatically applied to all projects unless overridden.
+
+## Current State Analysis
+
+### Current GitHub Token Handling
+- **Project-level only**: GitHub tokens are set per-project
+- **Manual entry required**: Users must enter GitHub token for each project
+- **Storage**: Tokens stored in K8s secrets per project
+- **UI Flow**: Token entry in project creation and update modals
+- **Database**: Project-level `github_key_set` boolean flag
+
+### Current Routes
+- `PUT /users/{user_id}/projects/{project_id}/github-key` - Update project GitHub key
+- Project creation includes optional GitHub key
+
+### Current Database Schema (MongoDB)
+```javascript
+// Projects collection
+{
+  "_id": ObjectId,
+  "user_id": "string",
+  "name": "string", 
+  "status": "active|inactive",
+  "github_key_set": boolean,
+  "sessions": [],
+  "created_at": Date,
+  "updated_at": Date
+}
+```
+
+## Task 2: Global GitHub PAT Management
+
+### Requirements
+
+#### User Experience
+1. **Global GitHub Token Setting**: Users can set a default GitHub token in their user profile
+2. **Automatic Application**: New projects automatically use the user's default GitHub token
+3. **Project Override**: Individual projects can still override the global token
+4. **Clear Indication**: UI shows whether project uses global or project-specific token
+5. **Token Management**: Users can update/remove their global GitHub token
+
+#### Technical Requirements
+1. **User-level Storage**: Store encrypted GitHub tokens per user
+2. **Automatic Inheritance**: Apply global token to new projects by default
+3. **Priority System**: Project-specific token overrides global token
+4. **Security**: Maintain existing security practices for token storage
+5. **Backward Compatibility**: Existing projects continue working unchanged
+
+### Database Schema Changes
+
+#### New Users Collection (MongoDB)
+```javascript
+// users collection (new)
+{
+  "_id": ObjectId,
+  "user_id": "string",     // matches existing user IDs
+  "name": "string",        // user display name
+  "github_token_set": boolean,
+  "created_at": Date,
+  "updated_at": Date
+}
+```
+
+#### Projects Collection Updates
+```javascript
+// projects collection (updated)
+{
+  "_id": ObjectId,
+  "user_id": "string",
+  "name": "string",
+  "status": "active|inactive", 
+  "github_key_set": boolean,
+  "github_key_source": "global|project",  // NEW: indicates token source
+  "sessions": [],
+  "created_at": Date,
+  "updated_at": Date
+}
+```
+
+### API Changes
+
+#### New User GitHub Token Routes
+```python
+# New routes to add
+PUT /users/{user_id}/github-key           # Set/update global GitHub token
+GET /users/{user_id}/github-key           # Get global GitHub token status  
+DELETE /users/{user_id}/github-key        # Remove global GitHub token
+```
+
+#### Modified Project Routes
+```python
+# Updated behavior for existing routes
+POST /users/{user_id}/projects            # Auto-apply global token if available
+PUT /users/{user_id}/projects/{project_id}/github-key  # Add option to use global token
+```
+
+### Service Layer Changes
+
+#### New `UserService` Methods
+```python
+class UserService:
+    def set_global_github_token(self, user_id: str, token: str) -> bool
+    def get_global_github_token(self, user_id: str) -> Optional[str] 
+    def remove_global_github_token(self, user_id: str) -> bool
+    def has_global_github_token(self, user_id: str) -> bool
+```
+
+#### Updated `ProjectService` Methods  
+```python
+class ProjectService:
+    def create_project_with_token_inheritance(self, user_id: str, project_data: dict) -> str
+    def get_effective_github_token(self, user_id: str, project_id: str) -> Optional[str]
+    def update_project_github_token_with_global_option(self, user_id: str, project_id: str, token: Optional[str], use_global: bool = False) -> bool
+```
+
+### Kubernetes Integration
+
+#### Token Storage Strategy
+1. **Global Tokens**: Store in user-specific K8s secrets (`user-{user_id}-global-secrets`)
+2. **Project Tokens**: Continue using existing project-specific secrets
+3. **Token Resolution**: During deployment, resolve effective token (project > global > none)
+
+#### Secret Management
+```yaml
+# User-level global secret
+apiVersion: v1
+kind: Secret
+metadata:
+  name: user-{user_id}-global-secrets
+  namespace: space-goose
+data:
+  github-token: <base64-encoded-token>
+```
+
+### UI/UX Changes
+
+#### User Settings Panel (New)
+```html
+<!-- New global settings section -->
+<div class="user-settings-panel">
+  <h3>🔑 Global GitHub Token</h3>
+  <div class="github-token-global">
+    <input type="password" placeholder="ghp_xxxxxxxxxxxxxxxxxxxx">
+    <button class="btn btn-primary">Set Global Token</button>
+    <button class="btn btn-outline">Remove Global Token</button>
+  </div>
+  <small class="form-help">
+    This token will be applied to all new projects by default.
+    Individual projects can override this setting.
+  </small>
+</div>
+```
+
+#### Updated Project Creation Modal
+```html
+<!-- Enhanced project creation -->
+<div class="form-group">
+  <label for="github-key-input">GitHub Token</label>
+  <select id="github-token-source">
+    <option value="global">Use Global Token (recommended)</option>
+    <option value="project">Set Project-Specific Token</option>
+    <option value="none">No GitHub Token</option>
+  </select>
+  <input type="password" id="project-github-key" style="display:none;">
+  <small class="form-help">
+    <span id="global-token-status">✅ Global token available</span>
+  </small>
+</div>
+```
+
+#### Updated Project Cards
+```html
+<!-- Enhanced GitHub status display -->
+<div class="github-token-status">
+  <span class="token-indicator global">🌐 Global Token</span>
+  <!-- OR -->
+  <span class="token-indicator project">🔑 Project Token</span>
+  <!-- OR -->
+  <span class="token-indicator none">🚫 No Token</span>
+</div>
+```
+
+## Implementation Steps
+
+### Phase 1: Database & Service Layer (Backend)
+1. **Create Users Collection**: Set up MongoDB users collection schema
+2. **Update Models**: Add new Pydantic models for user GitHub token management
+3. **Implement UserService**: Create service methods for global token management
+4. **Update ProjectService**: Modify to handle token inheritance
+5. **Add New Routes**: Implement user GitHub token API endpoints
+
+### Phase 2: Kubernetes Integration
+1. **User Secret Management**: Implement global secret creation/update
+2. **Token Resolution Logic**: Update deployment logic to resolve effective tokens
+3. **Migration Strategy**: Handle existing projects gracefully
+
+### Phase 3: Frontend Integration
+1. **User Settings UI**: Add global GitHub token management interface
+2. **Project Creation Flow**: Update project creation to use global tokens
+3. **Project Management**: Update project GitHub token management
+4. **Visual Indicators**: Add clear indicators for token sources
+
+### Phase 4: Migration & Testing  
+1. **Data Migration**: Migrate existing users to new schema
+2. **Backward Compatibility**: Ensure existing projects work unchanged
+3. **Testing**: Comprehensive testing of token inheritance logic
+4. **Documentation**: Update API documentation
+
+## New API Endpoints
+
+### User GitHub Token Management
+
+#### Set Global GitHub Token
+```http
+PUT /users/{user_id}/github-key
+Content-Type: application/json
+
+{
+  "github_token": "ghp_xxxxxxxxxxxxxxxxxxxx"
+}
+
+Response: 200 OK
+{
+  "message": "Global GitHub token set successfully"
+}
+```
+
+#### Get Global GitHub Token Status
+```http
+GET /users/{user_id}/github-key
+
+Response: 200 OK
+{
+  "has_global_token": true,
+  "created_at": "2023-12-07T10:30:00Z",
+  "updated_at": "2023-12-07T10:30:00Z"
+}
+```
+
+#### Remove Global GitHub Token
+```http
+DELETE /users/{user_id}/github-key
+
+Response: 200 OK
+{
+  "message": "Global GitHub token removed successfully"
+}
+```
+
+### Updated Project Endpoints
+
+#### Create Project with Token Inheritance
+```http
+POST /users/{user_id}/projects
+Content-Type: application/json
+
+{
+  "name": "my-project",
+  "github_token_source": "global" | "project" | "none",
+  "github_token": "ghp_xxx" // only if source is "project"
+}
+
+Response: 201 Created
+{
+  "message": "Project created successfully",
+  "project_id": "64a7b5c8e4b0a1b2c3d4e5f6",
+  "github_token_source": "global"
+}
+```
+
+#### Update Project GitHub Token with Global Option
+```http
+PUT /users/{user_id}/projects/{project_id}/github-key
+Content-Type: application/json
+
+{
+  "github_token_source": "global" | "project" | "none",
+  "github_token": "ghp_xxx" // only if source is "project"
+}
+
+Response: 200 OK
+{
+  "message": "Project GitHub token updated successfully",
+  "github_token_source": "global"
+}
+```
+
+## Security Considerations
+
+### Token Storage Security
+1. **Encryption**: All tokens encrypted before K8s secret storage
+2. **Access Control**: Only project deployments can access relevant tokens
+3. **Audit Trail**: Log token usage and updates
+4. **Scope Limitation**: Encourage minimal required GitHub token scopes
+
+### Token Resolution Priority
+```python
+def get_effective_github_token(user_id: str, project_id: str) -> Optional[str]:
+    """
+    Token priority: Project-specific > Global > None
+    """
+    # 1. Check for project-specific token
+    project_token = get_project_github_token(project_id)
+    if project_token:
+        return project_token
+        
+    # 2. Fall back to global user token
+    global_token = get_user_global_github_token(user_id)
+    if global_token:
+        return global_token
+        
+    # 3. No token available
+    return None
+```
+
+## Migration Strategy
+
+### Existing User Migration
+1. **Create User Records**: Generate user records for existing users
+2. **Preserve Project Tokens**: Existing project tokens remain unchanged  
+3. **Gradual Migration**: Users can optionally set global tokens
+4. **No Breaking Changes**: Existing functionality remains identical
+
+### Database Migration Script
+```python
+async def migrate_existing_users():
+    """
+    Create user records for existing project owners
+    """
+    projects = mongodb_service.list_all_projects()
+    users = set(project["user_id"] for project in projects)
+    
+    for user_id in users:
+        if not mongodb_service.user_exists(user_id):
+            mongodb_service.create_user_record({
+                "user_id": user_id,
+                "name": f"User {user_id}",  # Can be updated later
+                "github_token_set": False,
+                "created_at": datetime.utcnow(),
+                "updated_at": datetime.utcnow()
+            })
+```
+
+## Success Criteria
+
+### Functional Requirements
+- ✅ Users can set global GitHub tokens
+- ✅ New projects automatically inherit global tokens
+- ✅ Project-specific tokens override global tokens
+- ✅ Clear UI indication of token source
+- ✅ Existing projects continue working unchanged
+
+### Technical Requirements  
+- ✅ Secure token storage and encryption
+- ✅ Proper token resolution hierarchy
+- ✅ Database migration preserves existing data
+- ✅ API endpoints follow existing patterns
+- ✅ Comprehensive error handling
+
+### User Experience Requirements
+- ✅ Simplified project creation workflow
+- ✅ Clear token management interface
+- ✅ Intuitive token source indicators
+- ✅ Backward compatibility for existing users
+
+## Estimated Effort
+
+- **Database & Service Layer**: 1-2 days
+- **Kubernetes Integration**: 1 day  
+- **Frontend Implementation**: 1-2 days
+- **Testing & Migration**: 1 day
+- **Total**: 4-6 days
+
+## Risk Assessment
+
+- **Risk Level**: Medium
+- **Key Risks**: 
+  - Token storage security
+  - Migration complexity
+  - UI/UX confusion
+- **Mitigation**: 
+  - Comprehensive testing
+  - Gradual rollout
+  - Clear documentation
+  - User education
+
+## Future Enhancements
+
+1. **Multiple Global Tokens**: Support for multiple GitHub organizations
+2. **Token Validation**: Real-time GitHub token validation
+3. **Permission Scopes**: UI for managing GitHub token permissions
+4. **Token Rotation**: Automated token rotation capabilities
+5. **Audit Logging**: Comprehensive token usage auditing

--- a/k8s-manager/main.py
+++ b/k8s-manager/main.py
@@ -12,9 +12,9 @@ from fastapi_mcp import FastApiMCP
 from routes import project_routes
 
 app = FastAPI(
-    title="K8s Environment Manager", 
+    title="K8s Environment Manager",
     version="0.1.0",
-    description="A PoC application for managing Kubernetes-isolated user environments"
+    description="A PoC application for managing Kubernetes-isolated user environments",
 )
 
 # Add CORS middleware for development
@@ -30,13 +30,16 @@ templates = Jinja2Templates(directory="templates")
 
 app.include_router(project_routes.router)
 
+
 @app.get("/", response_class=HTMLResponse)
 async def read_root(request: Request):
     return templates.TemplateResponse("index.html", {"request": request})
 
+
 @app.get("/health")
 async def health_check():
     return {"status": "healthy"}
+
 
 mcp = FastApiMCP(
     app,
@@ -55,20 +58,15 @@ mcp = FastApiMCP(
         "create_session",
         "get_all_project_sessions",
         "get_session_messages",
-        "send_message",
+        "send_message_fire_and_forget",
         "get_all_project_settings",
         "get_specific_project_setting",
-        "update_project_setting", 
+        "update_project_setting",
         "reset_project_settings",
-        "update_project_settings_in_bulk"
-    ]
+        "update_project_settings_in_bulk",
+    ],
 )
 mcp.mount_http()
 
 if __name__ == "__main__":
-    uvicorn.run(
-        app, 
-        host="0.0.0.0", 
-        port=8000,
-        log_level="info"
-    )
+    uvicorn.run(app, host="0.0.0.0", port=8000, log_level="info")

--- a/k8s-manager/models.py
+++ b/k8s-manager/models.py
@@ -5,6 +5,7 @@ from datetime import datetime
 class ProjectCreate(BaseModel):
     name: str
     github_key: Optional[str] = None
+    use_global_github_key: Optional[bool] = True
 
 class ProjectUpdate(BaseModel):
     name: str
@@ -25,6 +26,7 @@ class Project(BaseModel):
     status: str  # active, inactive
     endpoint: Optional[str] = None
     github_key_set: Optional[bool] = False
+    github_key_source: Optional[str] = None  # "project" or "user"
     sessions: Optional[List[Session]] = []
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
@@ -32,6 +34,9 @@ class Project(BaseModel):
 class User(BaseModel):
     id: str
     name: str
+
+class UserGitHubKey(BaseModel):
+    github_key: str
 
 class ProjectUpdateGitHubKey(BaseModel):
     github_key: Optional[str] = None

--- a/k8s-manager/models.py
+++ b/k8s-manager/models.py
@@ -5,7 +5,6 @@ from datetime import datetime
 class ProjectCreate(BaseModel):
     name: str
     github_key: Optional[str] = None
-    use_global_github_key: Optional[bool] = True
 
 class ProjectUpdate(BaseModel):
     name: str
@@ -26,7 +25,6 @@ class Project(BaseModel):
     status: str  # active, inactive
     endpoint: Optional[str] = None
     github_key_set: Optional[bool] = False
-    github_key_source: Optional[str] = None  # "project" or "user"
     sessions: Optional[List[Session]] = []
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
@@ -35,10 +33,11 @@ class User(BaseModel):
     id: str
     name: str
 
-class UserGitHubKey(BaseModel):
-    github_key: str
-
 class ProjectUpdateGitHubKey(BaseModel):
+    github_key: Optional[str] = None
+
+# New model for user-level GitHub token
+class UserGitHubKey(BaseModel):
     github_key: Optional[str] = None
 
 class Extension(BaseModel):

--- a/k8s-manager/services/mongodb_service.py
+++ b/k8s-manager/services/mongodb_service.py
@@ -8,12 +8,16 @@ load_dotenv()
 MONGO_URI = os.getenv("MONGO_URI")
 MONGO_DB = os.getenv("MONGO_DB")
 PROJECTS_COLLECTION = "projects"
+USERS_COLLECTION = "users"
 
 client = MongoClient(MONGO_URI)
 db = client[MONGO_DB]
 
 def get_projects_collection():
     return db[PROJECTS_COLLECTION]
+
+def get_users_collection():
+    return db[USERS_COLLECTION]
 
 def list_projects(user_id: str):
     return list(get_projects_collection().find({"user_id": user_id}))
@@ -84,7 +88,7 @@ def update_session_in_project(project_id: str, session_id: str, session_data: di
         }
     )
 
-def store_github_key(project_id: str, github_key: str):
+def store_github_key(project_id: str, github_key: str, source: str = "project"):
     """Store GitHub key for a project (masked for security)"""
     # Store only a masked version for reference
     masked_key = f"{github_key[:8]}{'*' * (len(github_key) - 12)}{github_key[-4:]}" if len(github_key) > 12 else "*" * len(github_key)
@@ -94,6 +98,7 @@ def store_github_key(project_id: str, github_key: str):
             "$set": {
                 "github_key_masked": masked_key,
                 "github_key_set": True,
+                "github_key_source": source,
                 "updated_at": datetime.utcnow()
             }
         }
@@ -107,6 +112,7 @@ def update_github_key(project_id: str, github_key: str = None):
         update_data = {
             "github_key_masked": masked_key,
             "github_key_set": True,
+            "github_key_source": "project",
             "updated_at": datetime.utcnow()
         }
     else:
@@ -114,6 +120,7 @@ def update_github_key(project_id: str, github_key: str = None):
         update_data = {
             "$unset": {"github_key_masked": ""},
             "github_key_set": False,
+            "github_key_source": None,
             "updated_at": datetime.utcnow()
         }
     
@@ -124,3 +131,64 @@ def update_github_key(project_id: str, github_key: str = None):
 
 def delete_project(project_id: str):
     return get_projects_collection().delete_one({"_id": ObjectId(project_id)})
+
+# User-level GitHub token functions
+def get_user(user_id: str):
+    """Get user document or create it if it doesn't exist"""
+    user = get_users_collection().find_one({"user_id": user_id})
+    if not user:
+        # Create user document if it doesn't exist
+        get_users_collection().insert_one({
+            "user_id": user_id,
+            "created_at": datetime.utcnow(),
+            "updated_at": datetime.utcnow()
+        })
+        user = get_users_collection().find_one({"user_id": user_id})
+    return user
+
+def store_user_github_key(user_id: str, github_key: str):
+    """Store GitHub key for a user (masked for security)"""
+    # Store only a masked version for reference
+    masked_key = f"{github_key[:8]}{'*' * (len(github_key) - 12)}{github_key[-4:]}" if len(github_key) > 12 else "*" * len(github_key)
+    
+    # Ensure user exists
+    get_user(user_id)
+    
+    return get_users_collection().update_one(
+        {"user_id": user_id},
+        {
+            "$set": {
+                "github_key_masked": masked_key,
+                "github_key_set": True,
+                "updated_at": datetime.utcnow()
+            }
+        }
+    )
+
+def get_user_github_key_status(user_id: str):
+    """Check if a user has a GitHub key set"""
+    user = get_user(user_id)
+    return {
+        "github_key_set": user.get("github_key_set", False),
+        "github_key_masked": user.get("github_key_masked", None)
+    }
+
+def delete_user_github_key(user_id: str):
+    """Delete GitHub key for a user"""
+    return get_users_collection().update_one(
+        {"user_id": user_id},
+        {
+            "$unset": {"github_key_masked": ""},
+            "$set": {
+                "github_key_set": False,
+                "updated_at": datetime.utcnow()
+            }
+        }
+    )
+
+def get_user_github_key(user_id: str):
+    """Get the GitHub key for a user from secure storage"""
+    # This is a placeholder that would connect to a secure storage service in production
+    # For a real implementation, you would use a secure secrets manager
+    user = get_user(user_id)
+    return user.get("github_key", None) if user.get("github_key_set", False) else None

--- a/k8s-manager/services/mongodb_service.py
+++ b/k8s-manager/services/mongodb_service.py
@@ -34,10 +34,10 @@ def get_project(project_id: str):
     except:
         return None
 
-def update_project(project_id: str, update_data: dict):
+def update_project(project_id: str, operation: dict):
     return get_projects_collection().update_one(
         {"_id": ObjectId(project_id)},
-        {"$set": update_data}
+        operation
     )
 
 def update_project_status(project_id: str, status: str, endpoint: str = None):

--- a/k8s-manager/templates/index.html
+++ b/k8s-manager/templates/index.html
@@ -174,7 +174,11 @@
             font-size: 1rem;
         }
 
-
+        .content-actions {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+        }
 
         /* Projects Grid */
         .projects-grid {
@@ -639,7 +643,7 @@
             margin-bottom: 0.5rem;
         }
 
-        .form-group input {
+        .form-group input, .form-group select {
             width: 100%;
             padding: 0.75rem;
             border: 1px solid var(--border);
@@ -648,7 +652,7 @@
             transition: all 0.2s;
         }
 
-        .form-group input:focus {
+        .form-group input:focus, .form-group select:focus {
             outline: none;
             border-color: var(--primary);
             box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
@@ -659,6 +663,23 @@
             color: var(--text-muted);
             margin-top: 0.25rem;
             display: block;
+        }
+
+        .form-status {
+            font-size: 0.875rem;
+            padding: 0.75rem;
+            border-radius: var(--radius);
+            margin-top: 0.5rem;
+        }
+
+        .form-status.success {
+            background: rgba(5, 150, 105, 0.1);
+            color: var(--success);
+        }
+
+        .form-status.warning {
+            background: rgba(217, 119, 6, 0.1);
+            color: var(--warning);
         }
 
         .modal-footer {
@@ -773,6 +794,15 @@
             font-size: 0.875rem;
         }
 
+        /* GitHub Token Source indicators */
+        .github-source-global {
+            color: var(--primary) !important;
+        }
+
+        .github-source-project {
+            color: var(--success) !important;
+        }
+
         /* Responsive */
         @media (max-width: 768px) {
             .nav-content {
@@ -787,6 +817,10 @@
             .content-header-row {
                 flex-direction: column;
                 gap: 1rem;
+            }
+
+            .content-actions {
+                justify-content: flex-start;
             }
 
             .alert-overlay {
@@ -830,6 +864,9 @@
                             <option value="">Loading users...</option>
                         </select>
                     </div>
+                    <button id="user-settings-btn" class="btn btn-outline btn-xs" disabled>
+                        ⚙️ User Settings
+                    </button>
                 </div>
             </div>
         </nav>
@@ -845,7 +882,11 @@
                         </h2>
                         <p class="content-subtitle">Manage your Kubernetes environments and chat with AI assistants</p>
                     </div>
-
+                    <div class="content-actions">
+                        <div id="github-status-indicator" style="display: none; font-size: 0.875rem; color: rgba(255, 255, 255, 0.8);">
+                            <!-- GitHub status will be shown here -->
+                        </div>
+                    </div>
                 </div>
             </div>
 
@@ -886,6 +927,36 @@
         <!-- Alert Overlay Container -->
         <div class="alert-overlay" id="alert-overlay"></div>
 
+        <!-- User Settings Modal -->
+        <div class="modal-overlay" id="user-settings-modal">
+            <div class="modal">
+                <div class="modal-header">
+                    <h3>⚙️ User Settings</h3>
+                </div>
+                <div class="modal-body">
+                    <div class="form-group">
+                        <label for="global-github-key-input">Global GitHub Token</label>
+                        <input type="password" id="global-github-key-input" placeholder="ghp_xxxxxxxxxxxxxxxxxxxx">
+                        <small class="form-help">
+                            Set a default GitHub token that will be used for all new projects. 
+                            Individual projects can override this setting.
+                        </small>
+                        <div id="global-github-status" class="form-status" style="display: none;">
+                            <!-- Status will be shown here -->
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-outline" id="remove-global-github-btn" style="display: none;">Remove Global Token</button>
+                    <button class="btn btn-outline" id="cancel-user-settings-btn">Cancel</button>
+                    <button class="btn btn-primary" id="save-user-settings-btn">
+                        <span class="spinner" style="display: none;"></span>
+                        Save Settings
+                    </button>
+                </div>
+            </div>
+        </div>
+
         <!-- Create Project Modal -->
         <div class="modal-overlay" id="create-modal">
             <div class="modal">
@@ -898,9 +969,18 @@
                         <input type="text" id="project-name-input" placeholder="Enter a descriptive project name...">
                     </div>
                     <div class="form-group">
-                        <label for="github-key-input">GitHub Token</label>
-                        <input type="password" id="github-key-input" placeholder="ghp_xxxxxxxxxxxxxxxxxxxx">
-                        <small class="form-help">GitHub personal access token for private repositories</small>
+                        <label for="github-token-source">GitHub Token</label>
+                        <select id="github-token-source">
+                            <option value="global">Use Global Token (if available)</option>
+                            <option value="project">Set Project-Specific Token</option>
+                            <option value="none">No GitHub Token</option>
+                        </select>
+                        <div id="project-github-key-group" style="display: none; margin-top: 0.75rem;">
+                            <input type="password" id="github-key-input" placeholder="ghp_xxxxxxxxxxxxxxxxxxxx">
+                        </div>
+                        <div id="github-token-status" class="form-status" style="display: none;">
+                            <!-- Token status will be shown here -->
+                        </div>
                     </div>
                 </div>
                 <div class="modal-footer">
@@ -1059,6 +1139,7 @@
         let projectExtensions = [];
         let projectSettings = [];
         let settingsChanges = {}; // Track pending changes
+        let userGitHubKeySet = false; // Track global GitHub key status
 
         document.addEventListener('DOMContentLoaded', async () => {
             await initializeApp();
@@ -1088,6 +1169,144 @@
             modal.addEventListener('click', (e) => {
                 if (e.target === modal) closeSettingsModal();
             });
+        }
+
+        function setupUserSettingsModalHandlers() {
+            const modal = document.getElementById('user-settings-modal');
+            const cancelBtn = document.getElementById('cancel-user-settings-btn');
+            const saveBtn = document.getElementById('save-user-settings-btn');
+            const removeBtn = document.getElementById('remove-global-github-btn');
+            const githubKeyInput = document.getElementById('global-github-key-input');
+            const userSettingsBtn = document.getElementById('user-settings-btn');
+
+            userSettingsBtn.addEventListener('click', () => {
+                openUserSettingsModal();
+            });
+
+            cancelBtn.addEventListener('click', () => {
+                closeUserSettingsModal();
+            });
+
+            saveBtn.addEventListener('click', async () => {
+                const githubKey = githubKeyInput.value.trim();
+                await updateUserGitHubKey(githubKey);
+            });
+
+            removeBtn.addEventListener('click', async () => {
+                if (confirm('Are you sure you want to remove your global GitHub token?')) {
+                    await updateUserGitHubKey('');
+                }
+            });
+
+            githubKeyInput.addEventListener('keypress', async (e) => {
+                if (e.key === 'Enter') {
+                    const githubKey = githubKeyInput.value.trim();
+                    await updateUserGitHubKey(githubKey);
+                }
+            });
+
+            // Close modal on overlay click
+            modal.addEventListener('click', (e) => {
+                if (e.target === modal) closeUserSettingsModal();
+            });
+        }
+
+        function openUserSettingsModal() {
+            if (!currentUser) {
+                showAlert('Please select a user first', 'error');
+                return;
+            }
+
+            const modal = document.getElementById('user-settings-modal');
+            const input = document.getElementById('global-github-key-input');
+            const status = document.getElementById('global-github-status');
+            const removeBtn = document.getElementById('remove-global-github-btn');
+
+            input.value = '';
+            
+            if (userGitHubKeySet) {
+                status.innerHTML = '✅ You have a global GitHub token configured';
+                status.className = 'form-status success';
+                status.style.display = 'block';
+                removeBtn.style.display = 'inline-flex';
+            } else {
+                status.innerHTML = '⚠️ No global GitHub token configured - projects will need individual tokens';
+                status.className = 'form-status warning';
+                status.style.display = 'block';
+                removeBtn.style.display = 'none';
+            }
+
+            modal.classList.add('active');
+            setTimeout(() => input.focus(), 100);
+        }
+
+        function closeUserSettingsModal() {
+            const modal = document.getElementById('user-settings-modal');
+            modal.classList.remove('active');
+        }
+
+        async function updateUserGitHubKey(githubKey) {
+            const saveBtn = document.getElementById('save-user-settings-btn');
+            const spinner = saveBtn.querySelector('.spinner');
+
+            try {
+                saveBtn.disabled = true;
+                spinner.style.display = 'inline-block';
+
+                const requestBody = { github_key: githubKey };
+
+                const response = await fetch(`/users/${currentUser}/github-key`, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(requestBody)
+                });
+
+                if (response.ok) {
+                    const result = await response.json();
+                    showAlert(result.message, 'success');
+                    closeUserSettingsModal();
+                    
+                    // Update global status
+                    await loadUserGitHubKeyStatus();
+                    await loadProjects(currentUser);
+                    updateGitHubStatusIndicator();
+                } else {
+                    const error = await response.json();
+                    showAlert(error.detail || 'Failed to update global GitHub key', 'error');
+                }
+            } catch (error) {
+                showAlert('Failed to update global GitHub key', 'error');
+            } finally {
+                saveBtn.disabled = false;
+                spinner.style.display = 'none';
+            }
+        }
+
+        async function loadUserGitHubKeyStatus() {
+            if (!currentUser) return;
+
+            try {
+                const response = await fetch(`/users/${currentUser}/github-key`);
+                if (response.ok) {
+                    const data = await response.json();
+                    userGitHubKeySet = data.github_key_set;
+                } else {
+                    userGitHubKeySet = false;
+                }
+            } catch (error) {
+                userGitHubKeySet = false;
+            }
+        }
+
+        function updateGitHubStatusIndicator() {
+            const indicator = document.getElementById('github-status-indicator');
+            
+            if (currentUser && userGitHubKeySet) {
+                indicator.innerHTML = '🌐 Global GitHub Token Active';
+                indicator.style.display = 'block';
+            } else {
+                indicator.style.display = 'none';
+            }
         }
 
         // Settings Management Functions
@@ -1371,6 +1590,12 @@
                     currentUser = userId;
                     const userName = userSelect.options[userSelect.selectedIndex].text;
                     document.getElementById('current-user-name').textContent = userName;
+                    document.getElementById('user-settings-btn').disabled = false;
+                    
+                    // Load user GitHub key status
+                    await loadUserGitHubKeyStatus();
+                    updateGitHubStatusIndicator();
+                    
                     // Clear active project and session when user changes
                     activeProject = null;
                     currentSession = null;
@@ -1379,6 +1604,9 @@
                 } else {
                     currentUser = null;
                     document.getElementById('current-user-name').textContent = 'Select a user to continue';
+                    document.getElementById('user-settings-btn').disabled = true;
+                    userGitHubKeySet = false;
+                    updateGitHubStatusIndicator();
                     // Clear active project and session
                     activeProject = null;
                     currentSession = null;
@@ -1411,6 +1639,7 @@
             setupGitHubKeyModalHandlers();
             setupExtensionsModalHandlers();
             setupSettingsModalHandlers();
+            setupUserSettingsModalHandlers();
         }
 
         function setupGitHubKeyModalHandlers() {
@@ -1494,6 +1723,23 @@
             }
         }
 
+        function getGitHubTokenStatus(project) {
+            if (!project.github_key_set) {
+                return { text: '🚫 No GitHub Token', class: '' };
+            }
+            
+            // Check if project has github_key_source property
+            const source = project.github_key_source;
+            if (source === 'user') {
+                return { text: '🌐 Global Token', class: 'github-source-global' };
+            } else if (source === 'project') {
+                return { text: '🔑 Project Token', class: 'github-source-project' };
+            } else {
+                // Fallback for existing projects without source info
+                return { text: '🔑 GitHub Token Set', class: '' };
+            }
+        }
+
         function renderProjects(projectList) {
             const grid = document.getElementById('projects-grid');
 
@@ -1532,7 +1778,7 @@
                 const isActive = project.status === 'active';
                 const createdDate = project.created_at ? new Date(project.created_at).toLocaleDateString() : 'Unknown';
                 const sessions = project.sessions || [];
-                const githubKeyStatus = project.github_key_set ? '🔑 GitHub Token Set' : '🚫 No GitHub Token';
+                const githubStatus = getGitHubTokenStatus(project);
 
                 // Determine session action button
                 let sessionButton = '';
@@ -1583,7 +1829,7 @@
                         <div class="project-meta">
                             <div><span>Created:</span> <span>${createdDate}</span></div>
                             <div><span>Status:</span> <span>${isActive ? '🟢 Running' : '🔴 Stopped'}</span></div>
-                            <div><span>GitHub:</span> <span>${githubKeyStatus}</span></div>
+                            <div><span>GitHub:</span> <span class="${githubStatus.class}">${githubStatus.text}</span></div>
                             ${project.endpoint ? `<div><span>Endpoint:</span> <span>${project.endpoint}</span></div>` : ''}
                         </div>
                         
@@ -1625,6 +1871,14 @@
             const cancelBtn = document.getElementById('cancel-create-btn');
             const confirmBtn = document.getElementById('confirm-create-btn');
             const projectNameInput = document.getElementById('project-name-input');
+            const githubTokenSource = document.getElementById('github-token-source');
+            const projectGithubKeyGroup = document.getElementById('project-github-key-group');
+            const githubTokenStatus = document.getElementById('github-token-status');
+
+            // Handle token source change
+            githubTokenSource.addEventListener('change', () => {
+                updateGitHubTokenSourceDisplay();
+            });
 
             cancelBtn.addEventListener('click', () => {
                 closeCreateModal();
@@ -1632,11 +1886,7 @@
 
             confirmBtn.addEventListener('click', async () => {
                 const name = projectNameInput.value.trim();
-                const githubKey = document.getElementById('github-key-input').value.trim();
-                if (!githubKey) {
-                    showAlert('Please enter a github PAT', 'error');
-                    return;
-                }
+                
                 if (!name) {
                     showAlert('Please enter a project name', 'error');
                     return;
@@ -1645,14 +1895,10 @@
                 await createProject(name);
             });
 
-            // Handle Enter key in both inputs
+            // Handle Enter key in inputs
             projectNameInput.addEventListener('keypress', async (e) => {
                 if (e.key === 'Enter') {
                     const name = projectNameInput.value.trim();
-                    if (!githubKey) {
-                        showAlert('Please enter a github PAT', 'error');
-                        return;
-                    }
                     if (!name) {
                         showAlert('Please enter a project name', 'error');
                         return;
@@ -1664,15 +1910,11 @@
             document.getElementById('github-key-input').addEventListener('keypress', async (e) => {
                 if (e.key === 'Enter') {
                     const name = projectNameInput.value.trim();
-                if (!githubKey) {
-                    showAlert('Please enter a github PAT', 'error');
-                    return;
-                }
-                if (!name) {
-                    showAlert('Please enter a project name', 'error');
-                    return;
-                }
-                await createProject(name);
+                    if (!name) {
+                        showAlert('Please enter a project name', 'error');
+                        return;
+                    }
+                    await createProject(name);
                 }
             });
 
@@ -1708,6 +1950,34 @@
             });
         }
 
+        function updateGitHubTokenSourceDisplay() {
+            const tokenSource = document.getElementById('github-token-source').value;
+            const projectKeyGroup = document.getElementById('project-github-key-group');
+            const tokenStatus = document.getElementById('github-token-status');
+
+            if (tokenSource === 'project') {
+                projectKeyGroup.style.display = 'block';
+                tokenStatus.innerHTML = '🔑 You will set a project-specific GitHub token';
+                tokenStatus.className = 'form-status success';
+                tokenStatus.style.display = 'block';
+            } else if (tokenSource === 'global') {
+                projectKeyGroup.style.display = 'none';
+                if (userGitHubKeySet) {
+                    tokenStatus.innerHTML = '🌐 Project will use your global GitHub token';
+                    tokenStatus.className = 'form-status success';
+                } else {
+                    tokenStatus.innerHTML = '⚠️ No global token set - configure one in User Settings first';
+                    tokenStatus.className = 'form-status warning';
+                }
+                tokenStatus.style.display = 'block';
+            } else { // none
+                projectKeyGroup.style.display = 'none';
+                tokenStatus.innerHTML = '🚫 Project will have no GitHub token access';
+                tokenStatus.className = 'form-status warning';
+                tokenStatus.style.display = 'block';
+            }
+        }
+
         function openCreateModal() {
             if (!currentUser) {
                 showAlert('Please select a user first', 'error');
@@ -1717,9 +1987,19 @@
             const modal = document.getElementById('create-modal');
             const input = document.getElementById('project-name-input');
             const githubInput = document.getElementById('github-key-input');
+            const tokenSource = document.getElementById('github-token-source');
 
             input.value = '';
             githubInput.value = '';
+            
+            // Set default token source based on whether user has global token
+            if (userGitHubKeySet) {
+                tokenSource.value = 'global';
+            } else {
+                tokenSource.value = 'project';
+            }
+            
+            updateGitHubTokenSourceDisplay();
             modal.classList.add('active');
             setTimeout(() => input.focus(), 100);
         }
@@ -1758,11 +2038,15 @@
 
             // Set modal title and status
             title.textContent = hasKey ? 'Update GitHub Key' : 'Add GitHub Key';
+            
+            const project = projects.find(p => p.id === projectId);
+            const githubStatus = getGitHubTokenStatus(project || {});
+            
             if (hasKey) {
-                status.innerHTML = '\uD83D\uDD11 <strong>Current Status:</strong> GitHub token is set for this project';
+                status.innerHTML = `🔑 <strong>Current Status:</strong> ${githubStatus.text}`;
                 removeBtn.style.display = 'inline-flex';
             } else {
-                status.innerHTML = '\uD83D\uDEAB <strong>Current Status:</strong> No GitHub token set for this project';
+                status.innerHTML = '🚫 <strong>Current Status:</strong> No GitHub token set for this project';
                 removeBtn.style.display = 'none';
             }
 
@@ -2094,16 +2378,24 @@
         async function createProject(name) {
             const confirmBtn = document.getElementById('confirm-create-btn');
             const spinner = confirmBtn.querySelector('.spinner');
-            const githubKey = document.getElementById('github-key-input').value.trim();
+            const tokenSource = document.getElementById('github-token-source').value;
 
             try {
                 confirmBtn.disabled = true;
                 spinner.style.display = 'inline-block';
 
                 const requestBody = { name };
-                if (githubKey) {
+                
+                // Only include GitHub key if using project-specific token
+                if (tokenSource === 'project') {
+                    const githubKey = document.getElementById('github-key-input').value.trim();
+                    if (!githubKey) {
+                        showAlert('Please enter a GitHub token or choose a different option', 'error');
+                        return;
+                    }
                     requestBody.github_key = githubKey;
                 }
+                // For 'global' and 'none', don't include github_key in request
 
                 const response = await fetch(`/users/${currentUser}/projects`, {
                     method: 'POST',


### PR DESCRIPTION
## Global GitHub PAT Management

This PR implements global GitHub token management at the user level, allowing users to set a default GitHub token once that can be automatically inherited by their projects.

### Key Changes:
- Added new model `UserGitHubKey` for user-level GitHub token handling
- Implemented new endpoints in `project_routes.py`:
  - `PUT /users/{user_id}/github-key` - Set global GitHub token
  - `GET /users/{user_id}/github-key` - Check if global GitHub token exists
  - `DELETE /users/{user_id}/github-key` - Remove global GitHub token
- Enhanced MongoDB service with user token functions
- Extended K8s service to manage user-level GitHub tokens
- Updated project creation flow to inherit user's global token
- Added token source tracking (project-level vs user-level)

### Benefits:
- Users only need to set their GitHub token once
- Projects automatically inherit the global token
- Project-specific tokens take precedence over global tokens
- Clean fallback logic when tokens are removed